### PR TITLE
remove version field in favor of go-version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,6 @@ jobs:
         uses: actions/setup-go@master
         with:
           go-version: 1.13.x
-          version: 1.13.x
       -
         name: test
         run: |


### PR DESCRIPTION
As this field is deprecated https://github.com/actions/setup-go/blob/4efa1b82d1ccb78c5d339a7c908f557258cd9837/action.yml#L8, we can remove this.